### PR TITLE
Add missing `BangPatterns` language pragma

### DIFF
--- a/Crypto/Cipher/AES.hs
+++ b/Crypto/Cipher/AES.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE BangPatterns, MagicHash #-}
 -- |
 -- Module      : Crypto.Cipher.AES
 -- License     : BSD-style


### PR DESCRIPTION
This is needed as GHC 7.2.x doesn't enable the `BangPatterns` language
extension by default anymore.

This fixes #4
