### PR TITLE
Fix typo: EBC -> ECB

### DIFF
--- a/Crypto/Cipher/AES/Haskell.hs
+++ b/Crypto/Cipher/AES/Haskell.hs
@@ -128,7 +128,7 @@ encryptCBC key iv b
 				let r = coreEncrypt key $ B.pack $ B.zipWith xor iv' x in
 				r : encryptIter r xs
 
-{- | encrypt using simple EBC mode -}
+{- | encrypt using simple ECB mode -}
 encrypt :: Key -> B.ByteString -> B.ByteString
 encrypt key b
 	| B.length b `mod` 16 /= 0 = error "invalid data length"
@@ -147,7 +147,7 @@ decryptCBC key iv b
 				let r = B.pack $ B.zipWith xor iv' $ coreDecrypt key x in
 				r : decryptIter x xs
 
-{- | decrypt using simple EBC mode -}
+{- | decrypt using simple ECB mode -}
 decrypt :: Key -> B.ByteString -> B.ByteString
 decrypt key b
 	| B.length b `mod` 16 /= 0 = error "invalid data length"

--- a/Tests/AES.hs
+++ b/Tests/AES.hs
@@ -41,14 +41,14 @@ instance Arbitrary Key128 where
 instance Arbitrary Message where
     arbitrary = choose (1,102) >>= \sz -> Message <$> arbitraryBS (16*sz)
 
-ebcTests l (Key128 k, Message m) = (== 1) $ length $ nub $ map (\f -> f k m) l
+ecbTests l (Key128 k, Message m) = (== 1) $ length $ nub $ map (\f -> f k m) l
 cbcTests l (IV iv, Key128 k, Message m) = (== 1) $ length $ nub $ map (\f -> f k iv m) l
 
 unright (Right r) = r
 unright (Left e) = error e
 
 aesTests =
-    [ testProperty "ECB Encryption Equivalent" $ ebcTests
+    [ testProperty "ECB Encryption Equivalent" $ ecbTests
         [ (\k m -> AESHs.encrypt (unright $ AESHs.initKey128 k) m)
 #ifdef HAVE_AESNI
         , (\k m -> AESNI.encrypt (AESNI.initKey128 k) m)
@@ -60,7 +60,7 @@ aesTests =
         , (\k iv m -> AESNI.encryptCBC (AESNI.initKey128 k) iv m)
 #endif
         ]
-    , testProperty "ECB Decryption Equivalent" $ ebcTests
+    , testProperty "ECB Decryption Equivalent" $ ecbTests
         [ (\k m -> AESHs.decrypt (unright $ AESHs.initKey128 k) m)
 #ifdef HAVE_AESNI
         , (\k m -> AESNI.decrypt (AESNI.initKey128 k) m)


### PR DESCRIPTION
Hi Vincent,

I noticed that ECB was misspelled as EBC in the comments and also in the tests.  Interestingly, it was spelled correctly in the test description.  Just to be safe, I ran the tests.

Perhaps even better would be to add a warning about using ECB.  I can do that if you'd like.

Thanks,

Paulo
