### PR TITLE
Helper functions for implementing BlockCipher for Blowfish.

### DIFF
--- a/cryptocipher/Crypto/Cipher/Blowfish.hs
+++ b/cryptocipher/Crypto/Cipher/Blowfish.hs
@@ -8,7 +8,15 @@
 -- based on: BlowfishAux.hs (C) 2002 HardCore SoftWare, Doug Hoyte
 --           (as found in Crypto-4.2.4)
 
-module Crypto.Cipher.Blowfish (Blowfish, Key, initKey, encrypt, decrypt) where
+module Crypto.Cipher.Blowfish 
+    ( Blowfish
+    , Key
+    , initKey
+    , encrypt
+    , decrypt
+    , encryptBlock
+    , decryptBlock
+    , buildKey ) where
 
 import Data.Vector (Vector, (!), (//))
 import qualified Data.Vector as V
@@ -43,6 +51,14 @@ instance Serialize Key where
         case keyFromByteString bs of
             Right k -> return k
             Left _ -> fail "Invalid raw key material."
+
+-- These are useful for defining a BlockCipher instance
+encryptBlock, decryptBlock :: Blowfish -> B.ByteString -> B.ByteString
+encryptBlock = cipher . selectEncrypt . bfState
+decryptBlock = cipher . selectDecrypt . bfState
+buildKey :: B.ByteString -> Maybe Blowfish
+buildKey     = either (const Nothing) (Just . initBoxes) . initKey
+
 
 selectEncrypt, selectDecrypt :: BlowfishState -> (Pbox, BlowfishState)
 selectEncrypt x@(BF p _ _ _ _) = (p, x)


### PR DESCRIPTION
I'm updating Stephen's code related to issue #23.  His work-around for using a different key size for Blowfish was broken by your removing the BlockCipher interface altogether.  I tried making my own BlockCipher instance that uses only functions you export, but the result was that automated tests took 5 times as long to complete. If you accept this patch, then I can use this instance which runs much faster:

``` haskell
instance BlockCipher Blowfish128 where
    blockSize = Tagged 64
    encryptBlock (Blowfish128 b) = Blowfish.encryptBlock b
    decryptBlock (Blowfish128 b) = Blowfish.decryptBlock b
    buildKey                     = fmap Blowfish128 . Blowfish.buildKey 
    keyLength = Tagged 128
```
