### PR TITLE
Add source documentation for blowfish and camellia

### DIFF
--- a/cryptocipher/Crypto/Cipher/Blowfish.hs
+++ b/cryptocipher/Crypto/Cipher/Blowfish.hs
@@ -28,8 +28,16 @@ data BlowfishState = BF Pbox Sbox Sbox Sbox Sbox
 data Key = Key { unKey :: Vector Word32 }
     deriving (Eq, Show)
 
-encrypt, decrypt :: Key -> B.ByteString -> B.ByteString
+-- | Encrypts the given ByteString using the given Key
+encrypt :: Key          -- ^ The key to use
+        -> B.ByteString -- ^ The data to use
+        -> B.ByteString
 encrypt = cipher . selectEncrypt . bfState . initBoxes
+
+-- | Decrypts the given ByteString using the given Key
+decrypt :: Key          -- ^ The key to use
+        -> B.ByteString -- ^ The data to use
+        -> B.ByteString
 decrypt = cipher . selectDecrypt . bfState . initBoxes
 
 instance Serialize Blowfish where
@@ -58,7 +66,13 @@ initBoxes :: Key -> Blowfish
 initBoxes k = let (BF p s0 s1 s2 s3) = bfMakeKey k
               in Blowfish k (BF p s0 s1 s2 s3)
 
-initKey :: B.ByteString -> Either String Key
+-- | Initialize a key
+-- Return the initialized key or a error message when:
+-- - Keyseed was larger than 448 bits.
+-- - Expanded key length was incorrect
+-- - An internal error occured
+initKey :: B.ByteString -- ^ The seed to use when creating the key
+        -> Either String Key
 initKey b
     | B.length b > (448 `div` 8) = fail "key too large"
     | B.length b == 0 = keyFromByteString (B.replicate (18*4) 0)

--- a/cryptocipher/Crypto/Cipher/Camellia.hs
+++ b/cryptocipher/Crypto/Cipher/Camellia.hs
@@ -177,8 +177,13 @@ setKeyInterim keyseed =
 		in
 	(w64tow128 kL, w64tow128 kR, w64tow128 kA, w64tow128 kB)
 
-initKey128 :: B.ByteString -> Either String Key
-initKey128 keyseed
+-- | Initialize a 128-bit key
+-- Return the initialized key or a error message if the given 
+-- keyseed was not 16-bytes in length.
+--
+initKey128 :: B.ByteString -- ^ The seed to use when creating the key
+           -> Either String Key
+initKey128 keyseed 
 	| B.length keyseed /= 16 = Left "wrong key size"
 	| otherwise              =
 		let (kL, _, kA, _) = setKeyInterim keyseed in
@@ -320,10 +325,14 @@ doChunks f b =
 		then f x : doChunks f rest
 		else [ f x ]
 
-{- | encrypt with the key a bytestring and returns the encrypted bytestring -}
-encrypt :: Key -> B.ByteString -> B.ByteString
+-- | Encrypts the given ByteString using the given Key
+encrypt :: Key          -- ^ The key to use
+        -> B.ByteString -- ^ The data to encrypt
+        -> B.ByteString
 encrypt key b = B.concat $ doChunks (encryptChunk key) b
 
-{- | decrypt with the key a bytestring and returns the encrypted bytestring -}
-decrypt :: Key -> B.ByteString -> B.ByteString
+-- | Decrypts the given ByteString using the given Key
+decrypt :: Key          -- ^ The key to use
+        -> B.ByteString -- ^ The data to decrypt
+        -> B.ByteString
 decrypt key b = B.concat $ doChunks (decryptChunk key) b


### PR DESCRIPTION
Add documentation to exported functions for hackage.
Mainly because I had to read the source to find out when
the key initialization returned an error.

Hopefully these comments will make that clear for the next
person reading the documentation on hackage.
