### PR TITLE
don't use cipher-rc4 before 0.1.3, as it doesn't have the *Cipher classes

### DIFF
--- a/cryptocipher/cryptocipher.cabal
+++ b/cryptocipher/cryptocipher.cabal
@@ -16,7 +16,7 @@ Library
   Build-Depends:     base >= 4 && < 5
                    , crypto-cipher-types
                    , cipher-aes >= 0.2.3
-                   , cipher-rc4
+                   , cipher-rc4 >= 0.1.3
                    , cipher-des
                    , cipher-blowfish
                    , cipher-camellia


### PR DESCRIPTION
(broken in debian unstable)
